### PR TITLE
feat: add comprehensive AGENTS.md files for various components and services

### DIFF
--- a/3rd_party/iam/AGENTS.md
+++ b/3rd_party/iam/AGENTS.md
@@ -1,0 +1,38 @@
+# IAM Modules Agent Guide
+
+## Scope
+
+- Shared Keycloak integration libraries:
+  - `keycloak-core`: JWT claim parsing, principal creation, role mapping
+  - `keycloak-spring-starter`: Spring Boot auto-configuration for resource-server security
+- These modules are consumed by `service/tournamentmgmt` and are security-sensitive shared code.
+
+## Canonical Commands
+
+- Build/install both modules into local Maven repo: `../../service/tournamentmgmt/mvnw -B -f pom.xml install`
+- Run tests for the IAM reactor: `../../service/tournamentmgmt/mvnw -B -f pom.xml test`
+
+## Local Conventions
+
+- Keep `keycloak-core` free of Spring framework coupling except where already present.
+- Put Spring web/security auto-configuration in `keycloak-spring-starter`.
+- Preserve property names under `rallyon.security.keycloak.*`; downstream services already depend on them.
+- Maintain current role/claim semantics:
+  - mapped roles come from `realm_access.roles` and optionally `resource_access`
+  - numeric user id comes from the configured `rallyon_user_id`-style claim
+
+## Safety Boundaries
+
+- Do not relax token validation, issuer checks, audience checks, or authority mapping without explicit approval.
+- Do not silently change exception behavior for missing roles or missing user-id claims; downstream services rely on those failures being strict.
+- Avoid introducing service-specific assumptions here. Keep this subtree reusable.
+
+## Review Focus
+
+- Look for auth bypasses, broader permit-all behavior, or weaker validation.
+- Confirm tests cover claim parsing edge cases and Spring security wiring changes.
+
+## Done Criteria
+
+- Run `../../service/tournamentmgmt/mvnw -B -f pom.xml test`.
+- If downstream behavior changes, also run the affected service verification from `service/tournamentmgmt`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# RallyOn Agent Guide
+
+## Scope
+
+- `rallyon` is a mixed-language monorepo for badminton tournament tooling.
+- Active implementation areas today:
+  - `application/organizer`: Angular organizer portal
+  - `service/tournamentmgmt`: Spring Boot tournament management service
+  - `3rd_party/iam`: shared Keycloak security libraries used by backend services
+  - `tools/cli/ro`: Go developer CLI
+- Placeholder areas exist (`application/audience`, `service/playermgmt`, `service/scoring`) but currently contain no runnable app/service code.
+
+## Read This First
+
+- Check for a closer `AGENTS.md` before changing files in:
+  - `application/organizer/`
+  - `service/tournamentmgmt/`
+  - `3rd_party/iam/`
+  - `tools/cli/ro/`
+- Use the repo wiki as a normal research source, not just a submodule to avoid touching:
+  - read relevant pages in `wiki/` before making architecture, CLI workflow, docs, persona, or UX-flow assumptions
+  - treat code, config, manifests, and scripts as authoritative for commands, runtime behavior, and current implementation details
+  - treat the wiki as authoritative for intended architecture, workflow context, personas, and higher-level system framing unless contradicted by code or config
+- Prefer the smallest change that solves the task.
+- Do not clean up unrelated files, generated docs, or placeholders unless the task explicitly asks for it.
+- Preserve existing public APIs, CLI behavior, DB schema compatibility, and Keycloak contract unless the change explicitly authorizes a break.
+
+## Canonical Commands
+
+- Install root formatting deps: `npm ci`
+- Check tracked-file formatting: `npm run format:check`
+- Check changed-file formatting: `npm run format:check:changed`
+- Format changed files: `npm run format`
+- Organizer install: `npm run organizer:install`
+- Organizer dev server: `npm run organizer:dev`
+- Organizer lint: `npm run organizer:lint`
+- Organizer unit tests: `npm run organizer:test`
+- Organizer CI unit tests: `npm run organizer:test:ci`
+- Organizer e2e smoke: `npm run organizer:test:e2e`
+- Build shared IAM modules first when backend code depends on them:
+  - `./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml install`
+- Backend verify: `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+- CLI unit tests: `cd tools/cli/ro && go test ./...`
+
+## Validation Contract
+
+- Run the narrowest relevant checks for the area you changed.
+- If you touch multiple runtimes, validate each touched runtime.
+- Minimum expectations:
+  - Docs/scripts-only changes: `npm run format:check`
+  - Organizer UI changes: `npm run organizer:lint` and `npm run organizer:test:ci`
+  - Spring backend or IAM changes: install IAM if needed, then `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+  - Go CLI changes: `cd tools/cli/ro && go test ./...`
+- If a heavier check is skipped, say so explicitly in your handoff.
+
+## File Map
+
+- `application/organizer/`: Angular 21 standalone app, Tailwind v4, PrimeNG, Storybook, Playwright
+- `service/tournamentmgmt/`: Spring Boot 4 service, Spring Modulith, JPA, Flyway, PostgreSQL, OpenAPI
+- `3rd_party/iam/`: shared Keycloak core and Spring security auto-configuration
+- `admin/keycloak/`: local Keycloak provisioning script and operator notes
+- `infrastructure/local/`: local Docker Compose for Keycloak, Postgres, and tournament management service
+- `persistence/db/`: Postgres image used by local compose
+- `tools/cli/ro/`: Go Cobra CLI for build/test/run/deploy/docs/scaffolding workflows
+- `wiki/`: git submodule and expected agent research source for architecture, CLI workflows, personas, and design context
+
+## Architecture Boundaries
+
+- Keep organizer UI concerns in `application/organizer`; do not add backend or auth-server behavior there.
+- Keep service module boundaries intact in `service/tournamentmgmt`; `setup.configuration.api` is exposed, `internal` packages are not.
+- Treat `3rd_party/iam` as shared platform code. Changes there affect backend authentication behavior across services.
+- Do not add assumptions about `application/audience`, `service/playermgmt`, or `service/scoring`; they are placeholders today.
+
+## Safety Boundaries
+
+- Auth and identity:
+  - Keycloak issuer, JWKS, audience, role mapping, and `rallyon_user_id` claim handling are security-sensitive.
+  - Never hardcode real secrets. Prefer environment variables already used in docs/config.
+- Database and migrations:
+  - Flyway SQL in `service/tournamentmgmt/src/main/resources/db/migration/` is append-only. Add a new `V{n}__...sql`; do not rewrite shipped migrations.
+  - Favor backward-compatible schema changes unless explicitly asked otherwise.
+- Deploy and infra:
+  - `ro.yaml`, `.github/workflows/`, Dockerfiles, compose files, and `admin/keycloak/` impact delivery environments. Keep diffs intentional and minimal.
+- Wiki:
+  - `wiki/` is both a submodule and an expected research source.
+  - Read relevant wiki pages before planning architecture, CLI, or UX changes.
+  - Only update wiki content when the task explicitly requires wiki edits or generated docs there.
+
+## Change Policy
+
+- Prefer minimal diffs over broad restructures.
+- Preserve backward compatibility for:
+  - REST endpoints under `/api/tournamentmgmt/...`
+  - JWT claim expectations and role names
+  - `ro` CLI commands and flags
+- Do not rename directories, packages, or modules just for consistency.
+- Update nearby docs when command surfaces, env vars, workflows, or developer setup materially change.
+
+## Done Criteria
+
+- Relevant local checks pass, or skipped checks are called out.
+- New instructions/docs match actual repo commands.
+- No unrelated generated output, secrets, or environment-specific edits are introduced.

--- a/AGENTS_AUDIT.md
+++ b/AGENTS_AUDIT.md
@@ -1,0 +1,152 @@
+# AGENTS Audit
+
+## Proposed Files
+
+- `AGENTS.md`
+- `application/organizer/AGENTS.md`
+- `service/tournamentmgmt/AGENTS.md`
+- `3rd_party/iam/AGENTS.md`
+- `tools/cli/ro/AGENTS.md`
+
+## Why Each File Exists
+
+- `AGENTS.md`
+  - Gives repo-wide routing, safety rules, and canonical cross-project commands.
+  - Needed because this repo is a real monorepo with separate Node, Maven, and Go workflows plus infra/admin areas.
+- `application/organizer/AGENTS.md`
+  - Organizer has its own Angular/Storybook/Playwright/Tailwind/PrimeNG workflow and local UI/design conventions.
+- `service/tournamentmgmt/AGENTS.md`
+  - Backend service has distinct architecture rules, Flyway migration discipline, security boundaries, and Maven validation expectations.
+- `3rd_party/iam/AGENTS.md`
+  - Shared authentication modules are high-risk and affect backend security across the repo.
+- `tools/cli/ro/AGENTS.md`
+  - CLI work is operationally sensitive and uses a separate Go toolchain and compatibility surface.
+
+## Repo Evidence Used
+
+- Top-level purpose and layout:
+  - `README.md`
+  - `wiki/Home.md`
+  - `wiki/Architecture/Modules.md`
+- Root tooling:
+  - `package.json`
+  - `tools/scripts/check-format.sh`
+  - `tools/scripts/prettier-files.mjs`
+- CI and release workflows:
+  - `.github/workflows/build.yaml`
+  - `.github/workflows/Tournamentmgmt-docker.yaml`
+  - `.github/workflows/codeql.yml`
+  - `.github/workflows/ro-release.yml`
+- Organizer app evidence:
+  - `application/organizer/package.json`
+  - `application/organizer/README.md`
+  - `application/organizer/angular.json`
+  - `application/organizer/eslint.config.mjs`
+  - `application/organizer/playwright.config.ts`
+  - `application/organizer/src/app/app.routes.ts`
+  - `application/organizer/src/app/core/services/auth.service.ts`
+  - `application/organizer/src/styles/README.md`
+  - `application/organizer/design/pencil/README.md`
+  - `application/organizer/tests/login.spec.ts`
+  - `wiki/Personas.md`
+  - `wiki/design/frontend-spaceport-theme.md`
+- Tournament service evidence:
+  - `service/tournamentmgmt/pom.xml`
+  - `service/tournamentmgmt/src/main/resources/application.properties`
+  - `service/tournamentmgmt/src/main/resources/application-local.properties`
+  - `service/tournamentmgmt/src/main/resources/db/migration/V1__create_tournamentmgmt_schema.sql`
+  - `service/tournamentmgmt/src/main/resources/db/migration/V2__allow_nullable_fields_for_draft.sql`
+  - `service/tournamentmgmt/src/main/resources/db/migration/V3__extend_configuration_persistence.sql`
+  - `service/tournamentmgmt/src/main/resources/db/migration/V4__add_bracket_rosters.sql`
+  - `service/tournamentmgmt/src/main/resources/db/migration/V5__drop_legacy_venue_address.sql`
+  - `service/tournamentmgmt/src/test/java/dev/wlambertz/rallyon/tournamentmgmt/TournamentmgmtModuleStructureTest.java`
+  - `service/tournamentmgmt/src/test/java/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/web/ConfigurationControllerSecurityTest.java`
+  - `service/tournamentmgmt/docs/modulith/README.md`
+  - `wiki/Architecture/Tournamentmgmt-Modulith.md`
+- IAM evidence:
+  - `3rd_party/iam/pom.xml`
+  - `3rd_party/iam/keycloak-core/src/main/java/.../KeycloakPrincipalFactory.java`
+  - `3rd_party/iam/keycloak-spring-starter/src/main/java/.../KeycloakSecurityAutoConfiguration.java`
+- CLI evidence:
+  - `tools/cli/ro/README.md`
+  - `tools/cli/ro/go.mod`
+  - `tools/cli/ro/pkg/cmd/auth_test.go`
+  - `tools/cli/ro/pkg/cmd/deploy_test.go`
+  - `ro.yaml`
+  - `wiki/CLI-Manual.md`
+- Infra/admin evidence:
+  - `infrastructure/local/docker-compose.yml`
+  - `persistence/db/Dockerfile`
+  - `service/tournamentmgmt/Dockerfile`
+  - `admin/keycloak/README.md`
+  - `.devcontainer/devcontainer.json`
+  - `.devcontainer/post-create.sh`
+
+## Uncertainties And Assumptions
+
+- `application/audience`, `service/playermgmt`, and `service/scoring` appear to be placeholders only (`.keep`), so no subtree-specific `AGENTS.md` was added there.
+- The root `README.md` mentions Angular 20, but `application/organizer/package.json` currently uses Angular `^21.2.x`; the instructions follow the manifest/config rather than the stale README wording.
+- No root `Makefile`, Gradle build, pnpm workspace, or repo-wide task runner was found, so none were documented as canonical.
+- `codeql.yml` currently analyzes only GitHub Actions, so it was treated as a repo security signal rather than a source of build commands.
+- The instruction structure now treats `wiki/` as an explicit agent research source for architecture, workflows, personas, and design context, while code/config remain the source of truth for executable behavior.
+
+## Commands Discovered
+
+- Root:
+  - `npm ci`
+  - `npm run format`
+  - `npm run format:check`
+  - `npm run format:check:changed`
+  - `npm run organizer:install`
+  - `npm run organizer:dev`
+  - `npm run organizer:lint`
+  - `npm run organizer:test`
+  - `npm run organizer:test:ci`
+  - `npm run organizer:test:e2e`
+- Organizer:
+  - `npm install`
+  - `npm start`
+  - `npm run build`
+  - `npm run lint`
+  - `npm test`
+  - `npm run test:ci`
+  - `npm run test:e2e`
+  - `npm run storybook`
+  - `npm run build-storybook`
+  - `npx playwright install --with-deps chromium`
+- IAM / backend:
+  - `./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml install`
+  - `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+  - `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean package`
+  - `./mvnw -B clean verify` from `service/tournamentmgmt/`
+  - `./mvnw test -Dmodulith.docs=true -Dtest=TournamentmgmtDocumentationTests`
+- CLI:
+  - `cd tools/cli/ro && go test ./...`
+  - `cd tools/cli/ro && go build -o ../../bin/ro .`
+  - `cd tools/cli/ro && goreleaser build --snapshot --clean`
+  - `cd tools/cli/ro && goreleaser release --clean --skip=publish`
+- Local infra/docs from repo docs:
+  - `docker compose -f infrastructure/local/docker-compose.yml up -d keycloak tournamentmgmt-db`
+  - `ro doctor`
+  - `ro run service tournamentmgmt --env local --port 8080`
+  - `bash admin/keycloak/provision_keycloak.sh`
+
+## Notable Risks And Boundaries
+
+- Security and identity:
+  - Shared Keycloak libraries in `3rd_party/iam`
+  - Keycloak provisioning in `admin/keycloak`
+  - JWT audience/issuer/role/user-id-claim contract in backend config and tests
+- Database:
+  - Flyway migrations in `service/tournamentmgmt/src/main/resources/db/migration`
+  - PostgreSQL schema and enum evolution are compatibility-sensitive
+- Public API and compatibility:
+  - REST endpoints in `service/tournamentmgmt/.../web/ConfigurationController.java`
+  - Go CLI commands and flags in `tools/cli/ro/pkg/cmd`
+- Delivery and ops:
+  - GitHub workflows under `.github/workflows`
+  - `ro.yaml` deploy workflow references and safety gates
+  - Dockerfiles and `infrastructure/local/docker-compose.yml`
+- Docs and generated architecture artifacts:
+  - `service/tournamentmgmt/docs/modulith/generated/`
+  - `wiki/` is a submodule, so edits there should be deliberate

--- a/application/organizer/AGENTS.md
+++ b/application/organizer/AGENTS.md
@@ -1,0 +1,58 @@
+# Organizer Portal Agent Guide
+
+## Scope
+
+- Angular standalone organizer portal for login, dashboard, navigation, and UX-spike flows.
+- This subtree includes UI code, Storybook stories, Playwright smoke tests, and committed Pencil design sources.
+
+## Canonical Commands
+
+- Install: `npm install`
+- Dev server: `npm start`
+- Production build: `npm run build`
+- Lint: `npm run lint`
+- Unit tests: `npm test`
+- Headless unit tests: `npm run test:ci`
+- E2E smoke: `npm run test:e2e`
+- Storybook: `npm run storybook`
+- Static Storybook build: `npm run build-storybook`
+- Install Playwright browser when needed: `npx playwright install --with-deps chromium`
+
+## Local Conventions
+
+- Keep feature code under `src/app/features`, shell/navigation under `src/app/layout`, and cross-cutting logic under `src/app/core`.
+- Use standalone Angular components and existing route structure from `src/app/app.routes.ts`.
+- Keep feature-specific styling next to the component; only promote reusable styling into `src/styles/**` following the ITCSS-like layers documented in `src/styles/README.md`.
+- Use the wiki for product and art-direction context before changing major flows or visual language:
+  - `../../wiki/Personas.md` for audience and role framing
+  - `../../wiki/design/frontend-spaceport-theme.md` for the current organizer visual/theme brief
+- Respect the ESLint selector rules:
+  - directives: attribute selectors with `app` prefix
+  - components: element selectors with `app` prefix
+- Storybook is part of the workflow. If you add or materially change reusable UI, update or add the matching story when practical.
+
+## Boundaries
+
+- Current auth is a browser-only stub:
+  - `src/app/core/services/auth.service.ts` accepts `organizer / rallyon`
+  - session state is stored in `localStorage`
+- Do not present the current stub as production auth.
+- If wiki design/product guidance conflicts with code, package manifests, tests, or route behavior, follow the code and update the UI guidance around that reality.
+- Keep Pencil assets, Storybook references, and code tokens aligned:
+  - `design/pencil/*.pen`
+  - `src/stories/pencil-registry.ts`
+  - `src/styles/settings/_tokens.scss`
+  - `src/app/rallyonpreset.ts`
+  - `src/styles/elements/_typography.scss`
+
+## Risk Notes
+
+- Route guards and auth service changes affect the whole organizer shell.
+- Playwright smoke assumes the stub login flow and dashboard text; update tests with UI copy changes.
+- Tailwind/PrimeNG/theme changes can ripple broadly. Prefer validating with both unit tests and a quick app/storybook sanity check when feasible.
+
+## Done Criteria
+
+- Run `npm run lint` and `npm run test:ci` after code changes.
+- Run `npm run test:e2e` for login, routing, or shell-navigation changes.
+- If you changed shared visual primitives or design tokens, update the relevant Storybook story and committed Pencil source in the same branch when applicable.

--- a/service/tournamentmgmt/AGENTS.md
+++ b/service/tournamentmgmt/AGENTS.md
@@ -1,0 +1,61 @@
+# Tournament Management Service Agent Guide
+
+## Scope
+
+- Spring Boot 4 service for tournament configuration and lifecycle management.
+- Uses Spring Modulith, Spring Web, JPA, Flyway, PostgreSQL, Actuator, OpenAPI, and shared Keycloak auth from `3rd_party/iam`.
+
+## Canonical Commands
+
+- Install shared IAM artifacts first when needed: `./mvnw -B -f ../../3rd_party/iam/pom.xml install`
+- Run full verification: `./mvnw -B clean verify`
+- Package jar: `./mvnw -B clean package`
+- Generate Modulith docs only when intentionally refreshing them:
+  - `./mvnw test -Dmodulith.docs=true -Dtest=TournamentmgmtDocumentationTests`
+
+## Architecture Rules
+
+- Read wiki architecture context before restructuring modules or exposing new boundaries:
+  - `../../wiki/Architecture/Modules.md`
+  - `../../wiki/Architecture/Tournamentmgmt-Modulith.md`
+- Preserve Modulith boundaries verified by `TournamentmgmtModuleStructureTest`.
+- Exposed contracts live in `...setup.configuration.api`, `...setup.rules.api`, and `...setup.phases.api`.
+- Treat `...internal...` packages as non-public implementation details.
+- Keep web adapters in `...web`, use cases/services in `...internal...usecase`, and persistence in `...internal...persistence`.
+- The controller surface under `/api/tournamentmgmt/config` is compatibility-sensitive.
+- If wiki architecture intent conflicts with the actual module/test structure, follow the code and tests, then update docs deliberately if needed.
+
+## Database And Migration Rules
+
+- Flyway is enabled and migrations live in `src/main/resources/db/migration`.
+- Add new versioned SQL files for schema changes; do not edit existing `V1`-`V5` migrations unless the task is explicitly repairing an unreleased migration.
+- Default schema is `tournamentmgmt`; preserve schema qualification patterns.
+- Be careful with enum changes, constraints, and not-null transitions because existing draft lifecycle flows rely on them.
+
+## Security Rules
+
+- The service is an OAuth2 resource server via the shared Keycloak starter.
+- Do not weaken audience, issuer, role mapping, or `rallyon_user_id` claim requirements without explicit authorization.
+- Permit-all endpoints are intentionally limited to health/info, Swagger/OpenAPI, and local modulith actuator endpoints.
+- Security-sensitive controller changes should keep or extend test coverage similar to `ConfigurationControllerSecurityTest`.
+
+## Local Environment
+
+- Local defaults come from `src/main/resources/application.properties` plus `application-local.properties`.
+- Local stack:
+  - Keycloak on `:8081`
+  - Postgres on `:5432`
+  - Service on `:8080`
+- Compose file: `../../infrastructure/local/docker-compose.yml`
+
+## Risk Notes
+
+- Changes to `ConfigurationController`, API DTOs, persistence entities, or mapper logic can affect stored drafts and public API behavior.
+- Authentication changes here may actually belong in `../../3rd_party/iam`; check there before duplicating security code.
+- `docs/modulith/generated/` is committed generated architecture output. Update it only when intentionally regenerating Modulith docs.
+
+## Done Criteria
+
+- Run `./mvnw -B clean verify`.
+- If you changed authentication behavior, security config, or exposed endpoints, inspect or extend relevant tests.
+- If you regenerated Modulith docs, include the generated files intentionally and mention that in the handoff.

--- a/tools/cli/ro/AGENTS.md
+++ b/tools/cli/ro/AGENTS.md
@@ -1,0 +1,44 @@
+# `ro` CLI Agent Guide
+
+## Scope
+
+- Go-based developer CLI for RallyOn workflows: app orchestration, build/test/run, Docker, auth token helpers, docs generation, deploy helpers, and scaffolding.
+- This subtree is operationally sensitive because it can trigger deploy, docker push, workflow dispatches, and credentialed auth flows.
+
+## Canonical Commands
+
+- Unit tests: `go test ./...`
+- Local build: `go build -o ../../bin/ro .`
+- Multi-platform snapshot build: `goreleaser build --snapshot --clean`
+- Release dry run: `goreleaser release --clean --skip=publish`
+- Show command surface locally: `../../bin/ro --help` after building
+
+## Local Conventions
+
+- Keep command implementations under `pkg/cmd`.
+- Shared helpers belong in the dedicated support packages (`pkg/config`, `pkg/execx`, `pkg/fsx`, `pkg/logx`, `pkg/prompt`, `pkg/telemetry`, `pkg/version`).
+- Respect `ro.yaml` as the canonical project config for paths, workflows, deploy defaults, app scripts, and conventional-commit behavior.
+- Read `../../wiki/CLI-Manual.md` before changing command semantics, workflow descriptions, config behavior, or docs generation expectations.
+- Preserve command-line compatibility unless the task explicitly approves a breaking change.
+- If the wiki and implementation diverge, preserve the implemented CLI behavior and update docs intentionally rather than changing behavior to match stale prose.
+
+## Safety Boundaries
+
+- Treat deploy, docker push, auth token, and telemetry behavior as high-risk.
+- Prefer environment variables for secrets (`GITHUB_TOKEN`, `RALLYON_CLIENT_SECRET`, `RALLYON_DEV_PASSWORD`, etc.); do not add flags that encourage secrets in shell history unless the repo already does so.
+- Keep default safety gates intact:
+  - deploy clean-tree checks
+  - branch/ref guards
+  - green-build checks
+- Do not change workflow filenames or repo identifiers in `ro.yaml` casually; other commands use them directly.
+
+## Review Focus
+
+- Verify tests around branch guards, API calls, auth token resolution, and output formatting when touching command behavior.
+- Be careful with scaffolding/template changes because they affect newly generated backend modules.
+
+## Done Criteria
+
+- Run `go test ./...`.
+- Rebuild `../../bin/ro` if the task needs a local smoke check.
+- Mention clearly if you changed command flags, generated docs behavior, or deploy/auth defaults.


### PR DESCRIPTION
## Summary

Adds a repo-specific agent instruction system for RallyOn.

This PR introduces:
- a root `AGENTS.md` for repo-wide guidance
- scoped `AGENTS.md` files for the active implementation areas:
  - `application/organizer`
  - `service/tournamentmgmt`
  - `3rd_party/iam`
  - `tools/cli/ro`
- an `AGENTS_AUDIT.md` documenting:
  - why each file exists
  - which repo evidence was used
  - discovered commands
  - notable risks and architecture boundaries

The guidance is based on the actual repo structure, manifests, workflows, tests, infra, and wiki content, with explicit direction that the wiki is a research source while code/config remain the source of truth for executable behavior.

## Testing

- Ran `npm run format:check:changed`

## Notes

- This PR is documentation/instructions only.
- No application, service, CLI, schema, or infrastructure behavior was changed.
- The wiki is now explicitly treated as an agent knowledge source for architecture, CLI workflow, personas, and design context.
