### PR TITLE
Skills

### DIFF
--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -1,0 +1,150 @@
+# RallyOn System Policy
+
+## Mission
+
+Help engineers make safe, minimal, high-signal progress in the RallyOn monorepo for badminton tournament operations.
+
+Optimize for:
+
+- preserving working software and compatibility
+- respecting bounded contexts in a mixed-language monorepo
+- using the repo's real commands, tests, docs, and workflows
+- keeping security-sensitive auth, deploy, and data paths trustworthy
+
+## Scope
+
+This policy applies repo-wide.
+
+Active implementation areas today:
+
+- `application/organizer`: Angular organizer portal
+- `service/tournamentmgmt`: Spring Boot tournament management service
+- `3rd_party/iam`: shared Keycloak auth libraries
+- `tools/cli/ro`: Go developer CLI
+- supporting ops/docs areas such as `admin/keycloak`, `infrastructure/local`, `persistence/db`, `.github/workflows`, and `wiki/`
+
+Treat these as placeholders unless the task explicitly targets them:
+
+- `application/audience`
+- `service/playermgmt`
+- `service/scoring`
+
+## Priorities
+
+1. Preserve compatibility of the current system surface.
+2. Make the smallest change that solves the task.
+3. Follow owning-area boundaries instead of spreading logic across runtimes.
+4. Validate changes with the narrowest meaningful checks for each touched runtime.
+5. Keep docs and automation aligned with implemented behavior.
+
+## Hard Constraints
+
+### Compatibility
+
+- Preserve REST compatibility for endpoints under `/api/tournamentmgmt/...` unless a breaking change is explicitly requested.
+- Preserve `ro` CLI commands, flags, config semantics, workflow references, and safety gates unless a breaking change is explicitly requested.
+- Preserve Keycloak contract expectations: issuer, JWKS, audience, role mapping, and `rallyon_user_id` claim handling.
+- Preserve database compatibility where practical; Flyway migrations in `service/tournamentmgmt/src/main/resources/db/migration/` are append-only.
+
+### Security and secrets
+
+- Do not weaken auth validation, permit-all behavior, role mapping, or user-id claim requirements without explicit approval.
+- Never hardcode real secrets or introduce secret-bearing defaults. Prefer the repo's existing environment variables.
+- Treat deploy, docker push, auth-token, workflow-dispatch, and telemetry behavior as high-risk changes.
+
+### Boundaries
+
+- Keep organizer UI concerns in `application/organizer`.
+- Keep service logic inside existing Modulith boundaries in `service/tournamentmgmt`; public contracts live in `...api`, `...internal...` packages are implementation details.
+- Keep shared Keycloak behavior in `3rd_party/iam`, not duplicated ad hoc in services.
+- Do not edit generated or derived artifacts unless the task intentionally regenerates them.
+
+## Tool and Repo Navigation Policy
+
+### Read order
+
+Before editing, identify the owning area and read the closest applicable guidance:
+
+1. this `SYSTEM.md`
+2. root `AGENTS.md`
+3. the nearest subtree `AGENTS.md`
+4. a relevant repo-local `skills/*/SKILL.md` when the task matches a specialized workflow
+
+### Source of truth
+
+- Use code, tests, manifests, config, scripts, and workflow files as the source of truth for current behavior.
+- Use `wiki/` for intended architecture, workflow context, personas, and design direction unless code/tests/config contradict it.
+- Treat the root `README.md` as helpful background, not the canonical description of the current repo state; parts of it are stale.
+
+### Preferred commands
+
+- Use repo-defined commands and wrappers instead of inventing new ones.
+- Root formatting: `npm run format`, `npm run format:check`, `npm run format:check:changed`
+- Organizer: root `npm run organizer:*` wrappers or local `npm` scripts in `application/organizer`
+- Backend/IAM: `./service/tournamentmgmt/mvnw -B -f ...`
+- CLI: `cd tools/cli/ro && go test ./...`
+- Use `ro` for RallyOn-specific CLI workflows when the task concerns deploy, docker, docs generation, auth token helpers, or scaffold flows.
+
+## Change Policy
+
+- Prefer minimal diffs over broad cleanup or opportunistic refactors.
+- Do not rename modules, packages, directories, routes, command surfaces, or workflow files just for consistency.
+- Do not update `wiki/` unless the task explicitly calls for wiki edits or a generated wiki refresh.
+- Do not refresh committed Modulith docs, generated CLI reference, Storybook output, or other derived assets unless the task intentionally changes them.
+- When docs, automation, or command surfaces materially change, update the nearby authoritative docs in the same workstream.
+
+## Testing and Validation Expectations
+
+- Run the narrowest relevant checks for each touched area.
+- If multiple runtimes are touched, validate each touched runtime.
+- Minimum expectations:
+  - docs/scripts-only: `npm run format:check`
+  - organizer UI: `npm run organizer:lint` and `npm run organizer:test:ci`
+  - organizer login/routing/shell changes: also `npm run organizer:test:e2e`
+  - IAM changes: `./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml test`
+  - backend changes: install IAM first when needed, then `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+  - CLI changes: `cd tools/cli/ro && go test ./...`
+- If you intentionally skip a heavier check, say so explicitly in the handoff.
+
+## Documentation Policy
+
+- Keep instructions aligned with actual repo commands and current behavior.
+- Prefer updating the closest maintained doc rather than duplicating guidance in multiple places.
+- Use `docs/cli-reference.md` as generated output, not as the design source for CLI behavior.
+- Preserve the distinction between repo docs and the `wiki/` submodule; wiki updates are deliberate and may require separate commit handling.
+
+## Uncertainty and Fallback Behavior
+
+- If repo prose and implementation diverge, follow the implementation and tests for behavior, then update docs deliberately if needed.
+- If code and wiki diverge, preserve working code unless the task explicitly asks to realign behavior with intended architecture.
+- If a change touches security, deploy, database migrations, public API compatibility, or shared auth behavior and the intent is unclear, pause and surface the tradeoff instead of guessing.
+- If the repo lacks a convention, use a minimal local default that matches surrounding code and label it as a proposed convention in the handoff.
+
+## Instruction Precedence
+
+Use this precedence order:
+
+1. platform/system/developer instructions from the runtime
+2. direct user instructions for the task
+3. this `SYSTEM.md`
+4. root `AGENTS.md`
+5. the nearest subtree `AGENTS.md`
+6. explicitly invoked or clearly applicable repo-local `SKILL.md`
+7. other repo prose
+
+Within repo content:
+
+- a closer `AGENTS.md` overrides a broader one for that subtree
+- a relevant `SKILL.md` provides workflow-specific guidance and should not rewrite repo-wide policy
+- code/tests/config beat prose for executable behavior
+- wiki beats prose docs for intended architecture and workflow framing unless contradicted by code/tests/config
+
+## Boundaries: What Belongs in Skills Instead
+
+Keep `SYSTEM.md` stable and global. Put specialized, fast-changing workflows in Skills instead, especially:
+
+- organizer UI implementation and Pencil/Storybook sync
+- tournament service changes, Modulith conventions, and migration workflows
+- shared Keycloak/auth changes and local Keycloak bootstrap
+- `ro` CLI command development, release packaging, and deploy flows
+- cross-cutting repo routing for tasks spanning multiple active areas

--- a/skills/github-pr-author/SKILL.md
+++ b/skills/github-pr-author/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: github-pr-author
+description: draft GitHub pull request titles and Markdown bodies for the current RallyOn branch. Use for requests to write a PR body, summarize a branch for GitHub, draft reviewer-facing change notes, or produce Markdown for a pull request from the current diff and commit history.
+---
+
+# GitHub PR Author
+
+Use this skill when the user wants a GitHub-style pull request summary for the current branch.
+
+## Read before drafting
+
+1. [SYSTEM.md](../../SYSTEM.md)
+2. [AGENTS.md](../../AGENTS.md)
+3. Relevant area skill when the diff clearly targets one active subsystem:
+   - [skills/organizer-ui/SKILL.md](../../skills/organizer-ui/SKILL.md)
+   - [skills/tournamentmgmt-service/SKILL.md](../../skills/tournamentmgmt-service/SKILL.md)
+   - [skills/keycloak-auth/SKILL.md](../../skills/keycloak-auth/SKILL.md)
+   - [skills/ro-cli/SKILL.md](../../skills/ro-cli/SKILL.md)
+   - [skills/rallyon-repo-guide/SKILL.md](../../skills/rallyon-repo-guide/SKILL.md) for cross-cutting or repo-wide work
+
+## Workflow
+
+Before writing the PR content, inspect the branch itself:
+
+1. Current branch name
+2. Base branch
+3. Commit list on the branch
+4. Changed files
+5. Diff stat
+6. Key hunks when the summary needs more detail
+
+Treat the actual diff and commit history as the source of truth. Do not infer changes from open tabs, stale docs, or user shorthand when the branch says otherwise.
+
+## Writing rules
+
+- Default to GitHub-flavored Markdown.
+- Keep the writeup concise, factual, and reviewer-oriented.
+- Prefer describing user-visible or maintainer-relevant outcomes over restating every file touched.
+- Name the touched RallyOn subsystem when it helps orient reviewers:
+  - organizer UI
+  - tournament management service
+  - shared IAM / Keycloak auth
+  - `ro` CLI
+  - repo-wide docs, policy, or skills
+- Avoid overstating impact for docs-only, policy-only, or agent-guidance-only branches.
+- If testing was not run, say so plainly. Never invent validation.
+- Only include `## Risks / Notes` when the diff introduces meaningful reviewer context, follow-up items, compatibility concerns, or intentionally skipped checks.
+
+## Default output
+
+Use this structure unless the user asks for something shorter:
+
+```md
+## Summary
+
+Short paragraph describing the branch outcome.
+
+## What Changed
+
+- Concise bullets grouped by behavior or subsystem
+
+## Testing
+
+- Commands run, or `Not run`
+```
+
+Optional section when warranted:
+
+```md
+## Risks / Notes
+
+- Reviewer-relevant caveats, assumptions, or follow-up context
+```
+
+## RallyOn conventions
+
+- Align the testing section with RallyOn expectations from [SYSTEM.md](../../SYSTEM.md) and [AGENTS.md](../../AGENTS.md).
+- For docs-only or skills-only changes, it is usually enough to report `npm run format:check` when it was run.
+- When the diff spans multiple active runtimes, reflect that in the summary and list the validation performed for each touched area.
+- If the branch changes command surfaces, workflows, env vars, or setup expectations, mention the nearby docs updated to keep instructions aligned.
+
+## Title guidance
+
+If the user also wants a PR title, prefer a short title that reflects the reviewer-facing outcome of the branch, not just the most recent commit subject. Keep it specific to the subsystem and change type.

--- a/skills/keycloak-auth/SKILL.md
+++ b/skills/keycloak-auth/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: keycloak-auth
+description: work on RallyOn authentication, shared Keycloak integration, and local auth bootstrap. Use for changes in 3rd_party/iam, Keycloak issuer or audience handling, role or claim mapping, rallyon_user_id behavior, local realm provisioning, ro auth token flows, or service auth failures that may originate in shared auth code. Preserve strict validation and reuse the existing provisioning and local-token workflow.
+---
+
+# Keycloak Auth
+
+Use this skill for security-sensitive auth work spanning `3rd_party/iam`, local Keycloak bootstrap, and related service integration.
+
+## Read before editing
+
+1. [3rd_party/iam/AGENTS.md](../../3rd_party/iam/AGENTS.md)
+2. [admin/keycloak/README.md](../../admin/keycloak/README.md)
+3. [infrastructure/local/docker-compose.yml](../../infrastructure/local/docker-compose.yml)
+4. [wiki/CLI-Manual.md](../../wiki/CLI-Manual.md) section on `ro auth token` when the task touches token retrieval or local testing
+
+Inspect these implementation points as needed:
+
+- [admin/keycloak/provision_keycloak.sh](../../admin/keycloak/provision_keycloak.sh)
+- [tools/cli/ro/pkg/cmd/auth.go](../../tools/cli/ro/pkg/cmd/auth.go)
+
+## Safety rules
+
+- Do not relax token validation, issuer checks, audience checks, role mapping, or `rallyon_user_id` claim requirements without explicit approval.
+- Preserve property names under `rallyon.security.keycloak.*`.
+- Do not silently change failures for missing roles or missing user-id claims.
+- Keep shared IAM code reusable; do not bake service-specific assumptions into `3rd_party/iam` unless the repo already does.
+
+## Local bootstrap flow
+
+For local auth verification, reuse the repo’s existing flow:
+
+1. `docker compose -f infrastructure/local/docker-compose.yml up -d`
+2. Export required secrets such as `RALLYON_CLIENT_SECRET`
+3. `bash admin/keycloak/provision_keycloak.sh`
+4. `ro auth token --format bearer`
+5. Test via Swagger UI or service endpoints
+
+Prefer env vars over CLI flags for secrets so they do not land in shell history.
+
+## Validation
+
+- IAM module tests: `../../service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml test`
+- If downstream behavior changes, also run: `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`

--- a/skills/organizer-ui/SKILL.md
+++ b/skills/organizer-ui/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: organizer-ui
+description: work on the Angular organizer portal in application/organizer. Use for components, routes, auth-stub flows, shell or navigation changes, styling, PrimeNG theme work, Storybook stories, Playwright smoke coverage, or Pencil-backed design sync. Follow organizer subtree rules, preserve the current stub-auth reality, and keep Angular, Storybook, and Pencil assets aligned.
+---
+
+# Organizer UI
+
+Use this skill for work in `application/organizer/`.
+
+## Read before editing
+
+1. [application/organizer/AGENTS.md](../../application/organizer/AGENTS.md)
+2. [wiki/design/frontend-spaceport-theme.md](../../wiki/design/frontend-spaceport-theme.md) for visual direction
+3. [application/organizer/src/styles/README.md](../../application/organizer/src/styles/README.md) for style-layer conventions
+4. [application/organizer/design/pencil/README.md](../../application/organizer/design/pencil/README.md) when the task changes reusable UI, layout, or tokens
+
+Treat code as authoritative if docs and implementation diverge.
+
+## Working rules
+
+- Keep feature code under `src/app/features`, shell/navigation under `src/app/layout`, and cross-cutting logic under `src/app/core`.
+- Use standalone Angular patterns and existing routes from [application/organizer/src/app/app.routes.ts](../../application/organizer/src/app/app.routes.ts).
+- Keep feature styling next to the component. Only promote reusable styling into `src/styles/**`.
+- Respect ESLint selector rules with the `app` prefix.
+- Do not present the current browser-only auth stub as production auth.
+
+## Design sync
+
+When changing shared UI primitives, tokens, or screen layouts, keep these aligned when applicable:
+
+- [application/organizer/design/pencil/screens](../../application/organizer/design/pencil/screens)
+- [application/organizer/src/stories](../../application/organizer/src/stories)
+- [application/organizer/src/styles/settings/\_tokens.scss](../../application/organizer/src/styles/settings/_tokens.scss)
+- [application/organizer/src/app/rallyonpreset.ts](../../application/organizer/src/app/rallyonpreset.ts)
+- [application/organizer/src/styles/elements/\_typography.scss](../../application/organizer/src/styles/elements/_typography.scss)
+
+## Validation
+
+- `npm run organizer:lint`
+- `npm run organizer:test:ci`
+
+Also run `npm run organizer:test:e2e` when the task changes login flow, route guards, shell navigation, or dashboard text that Playwright depends on.
+
+Update or add the matching Storybook story when practical for reusable UI changes.

--- a/skills/rallyon-repo-guide/SKILL.md
+++ b/skills/rallyon-repo-guide/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rallyon-repo-guide
+description: route and execute work in the RallyOn monorepo. Use when a task is repo-wide, spans multiple runtimes, or does not clearly belong to organizer UI, tournamentmgmt backend, shared Keycloak auth, or the ro CLI. Follow the nearest AGENTS.md, read the relevant wiki pages before architecture or workflow changes, choose the smallest compatible change, and run the narrowest required validation for each touched area.
+---
+
+# RallyOn Repo Guide
+
+Use this skill first when the request is ambiguous, cross-cutting, or touches more than one active area.
+
+## Start here
+
+1. Read [AGENTS.md](../../AGENTS.md).
+2. Identify the owning area:
+   - `application/organizer`
+   - `service/tournamentmgmt`
+   - `3rd_party/iam`
+   - `tools/cli/ro`
+3. Read the closer `AGENTS.md` for each touched area before editing.
+4. Read relevant wiki pages before changing architecture, CLI semantics, docs, personas, or UX framing.
+
+## Source of truth
+
+- Treat code, manifests, configs, scripts, and tests as authoritative for current behavior.
+- Treat `wiki/` as authoritative for intended architecture, workflows, personas, and design direction unless code/tests contradict it.
+- Do not rely on the root `README.md` for current structure; it is stale.
+
+## Active areas
+
+- Organizer UI: [application/organizer/AGENTS.md](../../application/organizer/AGENTS.md)
+- Tournament service: [service/tournamentmgmt/AGENTS.md](../../service/tournamentmgmt/AGENTS.md)
+- Shared auth: [3rd_party/iam/AGENTS.md](../../3rd_party/iam/AGENTS.md)
+- Developer CLI: [tools/cli/ro/AGENTS.md](../../tools/cli/ro/AGENTS.md)
+
+Ignore placeholder domains unless the user explicitly wants to create them:
+
+- `application/audience`
+- `service/playermgmt`
+- `service/scoring`
+
+## Validation contract
+
+- Docs or scripts only: `npm run format:check`
+- Organizer UI: `npm run organizer:lint` and `npm run organizer:test:ci`
+- Backend or IAM: `./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml install` when needed, then `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+- Go CLI: `cd tools/cli/ro && go test ./...`
+
+If multiple runtimes are touched, validate each one. If a heavier check is skipped, call it out explicitly.
+
+## Safety rules
+
+- Prefer the smallest diff that solves the task.
+- Preserve REST compatibility under `/api/tournamentmgmt/...`, JWT claim expectations, role names, DB compatibility, and `ro` CLI flags unless the task explicitly allows a break.
+- Never rewrite shipped Flyway migrations.
+- Never hardcode secrets; prefer the env vars already documented in the repo.

--- a/skills/ro-cli/SKILL.md
+++ b/skills/ro-cli/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ro-cli
+description: maintain the RallyOn ro developer CLI and its workflow contracts. Use for changes in tools/cli/ro, ro.yaml, CLI docs generation, release packaging, deploy or docker wrappers, git helpers, auth token commands, or command-surface UX. Preserve command compatibility unless explicitly approved, keep docs in sync with the actual Cobra tree, and follow ro safety gates for deploy, docker, auth, and telemetry behavior.
+---
+
+# ro CLI
+
+Use this skill for work on `tools/cli/ro`, `ro.yaml`, and CLI-adjacent docs.
+
+## Read before editing
+
+1. [tools/cli/ro/AGENTS.md](../../tools/cli/ro/AGENTS.md)
+2. [wiki/CLI-Manual.md](../../wiki/CLI-Manual.md)
+3. [tools/cli/ro/README.md](../../tools/cli/ro/README.md)
+4. [ro.yaml](../../ro.yaml)
+
+Use [docs/cli-reference.md](../../docs/cli-reference.md) as generated output, not as the design source.
+
+## Working rules
+
+- Keep command implementations under [tools/cli/ro/pkg/cmd](../../tools/cli/ro/pkg/cmd).
+- Shared helpers belong in support packages like `pkg/config`, `pkg/execx`, `pkg/fsx`, `pkg/logx`, `pkg/prompt`, `pkg/telemetry`, and `pkg/version`.
+- Preserve command-line compatibility unless the task explicitly allows a breaking change.
+- If docs and implementation diverge, preserve implemented behavior and update docs intentionally instead of changing behavior to match stale prose.
+
+## Safety focus
+
+- Treat deploy, docker push, auth token, and telemetry behavior as high risk.
+- Prefer environment variables for secrets such as `GITHUB_TOKEN`, `RALLYON_CLIENT_SECRET`, and `RALLYON_DEV_PASSWORD`.
+- Keep default safety gates intact:
+  - clean-tree checks
+  - branch/ref guards
+  - green-build checks
+
+## Docs sync
+
+When command semantics or config behavior change, check whether these also need updates:
+
+- [wiki/CLI-Manual.md](../../wiki/CLI-Manual.md)
+- [tools/cli/ro/README.md](../../tools/cli/ro/README.md)
+- generated CLI reference via `ro docs generate`
+- related workflow files under [.github/workflows](../../.github/workflows)
+
+## Validation
+
+- `cd tools/cli/ro && go test ./...`
+- Rebuild `bin/ro` only when a local smoke check is useful:
+  - `cd tools/cli/ro && go build -o ../../bin/ro .`
+
+Use [tools/cli/ro/.goreleaser.yml](../../tools/cli/ro/.goreleaser.yml) and [ro-release.yml](../../.github/workflows/ro-release.yml) when packaging or release behavior is part of the task.

--- a/skills/tournamentmgmt-service/SKILL.md
+++ b/skills/tournamentmgmt-service/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: tournamentmgmt-service
+description: change the Spring Boot tournament management service in service/tournamentmgmt. Use for controllers, API DTOs, use cases, persistence, Flyway migrations, Modulith boundaries, OpenAPI-adjacent work, or service-level security changes. Preserve public API compatibility, respect exposed api vs internal packages, keep Flyway append-only, and validate with the Maven verify flow.
+---
+
+# Tournament Management Service
+
+Use this skill for work in `service/tournamentmgmt/`.
+
+## Read before editing
+
+1. [service/tournamentmgmt/AGENTS.md](../../service/tournamentmgmt/AGENTS.md)
+2. [wiki/Architecture/Modules.md](../../wiki/Architecture/Modules.md)
+3. [wiki/Architecture/Tournamentmgmt-Modulith.md](../../wiki/Architecture/Tournamentmgmt-Modulith.md)
+4. [service/tournamentmgmt/docs/modulith/README.md](../../service/tournamentmgmt/docs/modulith/README.md) when the task affects architecture docs or module boundaries
+
+## Architecture rules
+
+- Preserve Modulith boundaries checked by `TournamentmgmtModuleStructureTest`.
+- Exposed contracts live in:
+  - `...setup.configuration.api`
+  - `...setup.rules.api`
+  - `...setup.phases.api`
+- Treat `...internal...` packages as implementation details.
+- Keep controllers in `...web`, use cases/services in `...internal...usecase`, and persistence in `...internal...persistence`.
+- Treat `/api/tournamentmgmt/config` as compatibility-sensitive.
+
+## Database and migration rules
+
+- Migrations live in [service/tournamentmgmt/src/main/resources/db/migration](../../service/tournamentmgmt/src/main/resources/db/migration).
+- Add a new `V{n}__...sql` file for schema changes.
+- Do not rewrite shipped migrations unless the task explicitly says to repair an unreleased migration.
+- Favor backward-compatible schema changes.
+
+## Security rules
+
+- The service is an OAuth2 resource server backed by shared Keycloak code in `3rd_party/iam`.
+- Do not weaken issuer, audience, role mapping, or `rallyon_user_id` claim handling.
+- Security-sensitive endpoint changes should keep or extend test coverage similar to [service/tournamentmgmt/src/test/java/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/web/ConfigurationControllerSecurityTest.java](../../service/tournamentmgmt/src/test/java/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/web/ConfigurationControllerSecurityTest.java).
+
+## Validation
+
+If the change depends on shared IAM artifacts, install them first:
+
+`./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml install`
+
+Then run:
+
+`./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`
+
+Regenerate Modulith docs only when intentionally refreshing them:
+
+`./service/tournamentmgmt/mvnw test -Dmodulith.docs=true -Dtest=TournamentmgmtDocumentationTests`


### PR DESCRIPTION
## Summary

Adds RallyOn-specific Codex guidance so agent work in this monorepo follows the repo’s real boundaries, commands, and safety rules.

## What Changed

- Added a repo-wide `SYSTEM.md` that defines:
  - active vs placeholder areas in the monorepo
  - compatibility, security, and boundary rules
  - preferred command usage and validation expectations
  - instruction precedence between system policy, `AGENTS.md`, and repo-local skills
- Added focused skills under `skills/` for the main active work areas:
  - `rallyon-repo-guide` for cross-cutting or ambiguous tasks
  - `organizer-ui` for Angular organizer portal work
  - `tournamentmgmt-service` for Spring Boot service work
  - `ro-cli` for the Go developer CLI
  - `keycloak-auth` for shared IAM and local Keycloak flows

## Why

- Gives agents a stable repo-wide policy without overloading `AGENTS.md`
- Moves fast-changing, area-specific workflows into targeted skills
- Reinforces minimal diffs, compatibility preservation, and runtime-appropriate validation across the monorepo

## Testing

- Not run
- This branch adds agent guidance and skill documentation only
