### PR TITLE
[codex] docs: record tournamentmgmt Kotlin build-tool decision

### DIFF
--- a/service/tournamentmgmt/docs/kotlin-migration-build-tool-decision.md
+++ b/service/tournamentmgmt/docs/kotlin-migration-build-tool-decision.md
@@ -1,0 +1,37 @@
+# Kotlin Migration Build-Tool Decision
+
+## Status
+
+Accepted for the tournamentmgmt Kotlin migration.
+
+## Decision
+
+The `service/tournamentmgmt` Kotlin migration starts on Maven. Gradle is not a prerequisite for adding mixed Java/Kotlin support or for converting service code incrementally.
+
+## Rationale
+
+- The tournamentmgmt service already builds through the Maven wrapper in `service/tournamentmgmt/mvnw`.
+- Existing repo automation is Maven-oriented: `ro` build and run commands, GitHub Actions, Sonar analysis, Docker packaging, and the local IAM install flow all expect Maven.
+- Maven supports mixed Java/Kotlin projects, which matches the intended migration path: add Kotlin support first, then convert code in small compatibility-preserving steps.
+- Keeping Maven reduces the blast radius of the first migration PRs. The language migration can be validated independently from any future build-tool migration.
+
+## Deferred Gradle Evaluation
+
+Revisit Gradle only after the Maven-based Kotlin migration is stable, or if Maven becomes a measured blocker. A separate Gradle spike should include evidence for at least one of these criteria:
+
+- Clean or incremental Maven builds are materially too slow for local or CI feedback.
+- Remote build cache support becomes necessary for reliable developer or CI throughput.
+- Gradle convention plugins would meaningfully reduce duplicated JVM build configuration.
+- A repo-wide JVM multi-project build strategy becomes more valuable than preserving the current Maven flow.
+
+Any Gradle proposal must compare build, test, package, Sonar, Docker, `ro`, IAM install, CI, and onboarding impact before replacing Maven.
+
+## Validation
+
+This decision note does not change build behavior. Validate it with:
+
+```bash
+npm run format:check:changed
+```
+
+Run service verification only if a follow-up PR changes build files or service code.


### PR DESCRIPTION
## Summary

- Add a tournamentmgmt decision note for the Kotlin migration build-tool baseline.
- Record Maven as the starting point and document why Gradle is deferred.
- Define criteria for a future Gradle evaluation without changing build behavior.

## Validation

- `npm run format:check:changed`

Closes #99