### PR TITLE
Add Kotlin build foundation on Java 21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25.8-bookworm AS go-toolchain
 
-FROM eclipse-temurin:25.0.2_10-jdk-jammy AS java-toolchain
+FROM eclipse-temurin:21-jdk-jammy AS java-toolchain
 
 FROM node:20.20.1-bookworm AS node-toolchain
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
       "settings": {
         "java.configuration.runtimes": [
           {
-            "name": "JavaSE-25",
+            "name": "JavaSE-21",
             "path": "/opt/java/openjdk",
             "default": true
           }

--- a/.github/workflows/Tournamentmgmt-docker.yaml
+++ b/.github/workflows/Tournamentmgmt-docker.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "25"
+          java-version: "21"
           cache: maven
 
       - name: Make Maven wrapper executable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,10 +35,10 @@ jobs:
       - name: Organizer unit tests (headless)
         run: npm run test:ci
         working-directory: application/organizer
-      - name: Set up JDK 25
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 25
+          java-version: 21
           distribution: "zulu" # Alternative distribution options are available.
       - name: Cache SonarQube packages
         uses: actions/cache@v5

--- a/3rd_party/iam/keycloak-core/pom.xml
+++ b/3rd_party/iam/keycloak-core/pom.xml
@@ -11,7 +11,7 @@
     <description>Framework-agnostic Keycloak IAM helpers for RallyOn services.</description>
 
     <properties>
-        <maven.compiler.release>25</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>6.1.0</junit.version>
         <assertj.version>3.27.7</assertj.version>

--- a/3rd_party/iam/keycloak-spring-starter/pom.xml
+++ b/3rd_party/iam/keycloak-spring-starter/pom.xml
@@ -18,7 +18,7 @@
     <description>Spring Boot auto-configuration for Keycloak backed RallyOn services.</description>
 
     <properties>
-        <java.version>25</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/3rd_party/iam/keycloak-spring-starter/src/test/java/dev/wlambertz/rallyon/iam/keycloak/spring/KeycloakSecurityAutoConfigurationTest.java
+++ b/3rd_party/iam/keycloak-spring-starter/src/test/java/dev/wlambertz/rallyon/iam/keycloak/spring/KeycloakSecurityAutoConfigurationTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
-import org.springframework.boot.security.oauth2.server.resource.autoconfigure.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/service/tournamentmgmt/Dockerfile
+++ b/service/tournamentmgmt/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM eclipse-temurin:26.0.1_8-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
 # Use a dedicated user instead of root for runtime hardening

--- a/service/tournamentmgmt/pom.xml
+++ b/service/tournamentmgmt/pom.xml
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<sonar.organization>wlambertz-dev</sonar.organization>
-		<java.version>25</java.version>
+		<java.version>21</java.version>
 		<spring-modulith.version>2.1.0</spring-modulith.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
 		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
@@ -50,6 +50,18 @@
 		<dependency>
 			<groupId>org.springframework.modulith</groupId>
 			<artifactId>spring-modulith-starter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>dev.wlambertz.rallyon.iam</groupId>
@@ -88,7 +100,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.modulith</groupId>
-			<artifactId>spring-modulith-observability</artifactId>
+			<artifactId>spring-modulith-observability-core</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -147,8 +159,86 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<configuration>
+					<jvmTarget>${java.version}</jvmTarget>
+					<args>
+						<arg>-Xannotation-default-target=param-property</arg>
+					</args>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+						<plugin>jpa</plugin>
+					</compilerPlugins>
+				</configuration>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-noarg</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<annotationProcessorPaths>
 						<path>

--- a/tools/cli/ro/README.md
+++ b/tools/cli/ro/README.md
@@ -25,18 +25,18 @@ go build -o ../../bin/ro .  # -o sets output path, trailing dot builds current m
 ```bash
 # install or point to a JDK that Maven can see
 # example: use Windows JDK from WSL (quotes handle spaces)
-export JAVA_HOME="/mnt/c/Users/wla_edu/tools/jdk-25"
+export JAVA_HOME="/mnt/c/Users/wla_edu/tools/jdk-21"
 export PATH="$JAVA_HOME/bin:$PATH"
 
 # or, if you installed a Linux JDK in WSL (Temurin via APT)
-# sudo apt update && sudo apt install -y temurin-17-jdk temurin-25-jdk
-export JAVA_HOME="/usr/lib/jvm/temurin-25-jdk-amd64"
+# sudo apt update && sudo apt install -y temurin-21-jdk
+export JAVA_HOME="/usr/lib/jvm/temurin-21-jdk-amd64"
 export PATH="$JAVA_HOME/bin:$PATH"
 
 # add the export once to ~/.bashrc to persist (idempotent append)
-if ! grep -q 'temurin-25-jdk-amd64' ~/.bashrc; then
+if ! grep -q 'temurin-21-jdk-amd64' ~/.bashrc; then
   cat >> ~/.bashrc <<'EOF'
-export JAVA_HOME="/usr/lib/jvm/temurin-25-jdk-amd64"
+export JAVA_HOME="/usr/lib/jvm/temurin-21-jdk-amd64"
 export PATH="$JAVA_HOME/bin:$PATH"
 EOF
 fi
@@ -93,8 +93,7 @@ read -rsp "Developer password: " RALLYON_DEV_PASSWORD && export RALLYON_DEV_PASS
 ro auth token --format bearer
 ```
 
-If Keycloak is not reachable at `http://localhost:8081` from your shell environment, pass `--server` or set `KEYCLOAK_SERVER`.
-Prefer environment variables over `--client-secret` or `--password` so secrets do not end up in shell history.
+If Keycloak is not reachable at `http://localhost:8081` from your shell environment, pass `--server` or set `KEYCLOAK_SERVER`. Prefer environment variables over `--client-secret` or `--password` so secrets do not end up in shell history.
 
 - Build / Test / Run
 


### PR DESCRIPTION
## Summary

- add Maven Kotlin build support to `service/tournamentmgmt` without converting production code
- rebaseline backend Java targets, CI, devcontainer, runtime image, and developer docs to Java 21 for the Kotlin migration phase
- replace the POM-only `spring-modulith-observability` dependency with `spring-modulith-observability-core`
- update the IAM Spring Boot 4.1 resource-server auto-configuration test import

## Rationale

Issue #100 starts the executable Kotlin migration path. Java 21 is the safer baseline for this phase because it is broadly available locally and in agent environments while still being supported by Spring Boot 4.1 and Kotlin. Keeping Kotlin's `jvmTarget` tied to `${java.version}` keeps Java and Kotlin bytecode aligned.

## Validation

- `npm run format:check:changed`
- `git diff --check`
- `bash ./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml validate`
- `bash ./service/tournamentmgmt/mvnw -B -f 3rd_party/iam/pom.xml install`
- `bash ./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`

Closes #100
