### PR TITLE
fix(tournamentmgmt): jvmrecord removal follow-ups

### DIFF
--- a/service/tournamentmgmt/pom.xml
+++ b/service/tournamentmgmt/pom.xml
@@ -168,6 +168,9 @@
 					<jvmTarget>${java.version}</jvmTarget>
 					<args>
 						<arg>-Xannotation-default-target=param-property</arg>
+						<!-- Kotlin data classes are no longer @JvmRecord, so MapStruct's kapt-based
+						     TournamentMapper has no record-component metadata to resolve constructor
+						     parameter names from; -java-parameters keeps that name resolution working. -->
 						<arg>-java-parameters</arg>
 					</args>
 					<compilerPlugins>

--- a/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/Capacity.kt
+++ b/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/Capacity.kt
@@ -1,5 +1,6 @@
 package dev.wlambertz.rallyon.tournamentmgmt.setup.configuration.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.Positive
 
@@ -7,8 +8,10 @@ data class Capacity(
     @field:Positive(message = "Capacity amount must be positive") val amount: Int?,
     val unit: Unit?
 ) {
+    @JsonIgnore
     fun isUnbounded(): Boolean = amount == null
 
+    @JsonIgnore
     @AssertTrue(message = "Capacity unit must be provided when amount is set")
     fun isUnitConsistent(): Boolean = amount == null || unit != null
 

--- a/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/DisciplineConfig.kt
+++ b/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/DisciplineConfig.kt
@@ -25,7 +25,8 @@ data class DisciplineConfig(
             teamSize: TeamSize,
             brackets: List<BracketConfig>
         ): DisciplineConfig =
-            // Defensive copy lives in the factory to keep the primary constructor simple.
+            // brackets is a constructor val: it can't be reassigned or intercepted anywhere in the
+            // class body, so the defensive copy has to happen here, before the primary constructor runs.
             DisciplineConfig(id, category, displayName, teamSize, java.util.List.copyOf(brackets))
     }
 }

--- a/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/ParticipantsRoster.kt
+++ b/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/ParticipantsRoster.kt
@@ -1,11 +1,13 @@
 package dev.wlambertz.rallyon.tournamentmgmt.setup.configuration.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.validation.constraints.AssertTrue
 
 data class ParticipantsRoster(
     val playerIds: List<Long>?,
     val teamIds: List<Long>?
 ) {
+    @JsonIgnore
     @AssertTrue(message = "Exactly one of playerIds or teamIds must be set")
     fun isExclusiveRoster(): Boolean = (playerIds == null) != (teamIds == null)
 }

--- a/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/Venue.kt
+++ b/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/Venue.kt
@@ -1,5 +1,6 @@
 package dev.wlambertz.rallyon.tournamentmgmt.setup.configuration.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotBlank
@@ -10,6 +11,7 @@ data class Venue(
     @field:Valid val address: Address?,
     @field:Valid val peopleCapacity: Capacity?
 ) {
+    @JsonIgnore
     @AssertTrue(message = "Venue capacity must use PEOPLE unit when amount is set")
     fun isPeopleCapacityConsistent(): Boolean =
         peopleCapacity == null || peopleCapacity.amount == null || peopleCapacity.unit == Capacity.Unit.PEOPLE

--- a/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/rules/api/ScoringRules.kt
+++ b/service/tournamentmgmt/src/main/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/rules/api/ScoringRules.kt
@@ -1,5 +1,6 @@
 package dev.wlambertz.rallyon.tournamentmgmt.setup.rules.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
@@ -18,6 +19,7 @@ data class ScoringRules(
         }
     }
 
+    @JsonIgnore
     @AssertTrue(message = "Cap points must exceed points per game when defined")
     fun isCapPointsConsistent(): Boolean = capPoints == null || capPoints > pointsPerGame
 

--- a/service/tournamentmgmt/src/test/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/ApiJsonSerializationTest.kt
+++ b/service/tournamentmgmt/src/test/kotlin/dev/wlambertz/rallyon/tournamentmgmt/setup/configuration/api/ApiJsonSerializationTest.kt
@@ -1,0 +1,49 @@
+package dev.wlambertz.rallyon.tournamentmgmt.setup.configuration.api
+
+import dev.wlambertz.rallyon.tournamentmgmt.setup.rules.api.ScoringRules
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * Locks in that @AssertTrue validation-helper methods (isXxx()) on the
+ * Kotlin-migrated API data classes don't leak into JSON responses. Jackson's
+ * java.lang.Record introspection (used while these types were @JvmRecord)
+ * only serializes record components; plain-data-class introspection treats
+ * any isXxx(): Boolean method as an implicit getter unless told otherwise.
+ */
+class ApiJsonSerializationTest {
+
+    private val mapper = JsonMapper.builder().findAndAddModules().build()
+
+    @Test
+    fun `capacity serializes only its declared properties`() {
+        val json = mapper.writeValueAsString(Capacity(10, Capacity.Unit.PEOPLE))
+
+        assertEquals(setOf("amount", "unit"), mapper.readTree(json).propertyNames().toSet())
+    }
+
+    @Test
+    fun `venue serializes only its declared properties`() {
+        val json = mapper.writeValueAsString(Venue("Stadthalle", null, null))
+
+        assertEquals(setOf("name", "address", "peopleCapacity"), mapper.readTree(json).propertyNames().toSet())
+    }
+
+    @Test
+    fun `participants roster serializes only its declared properties`() {
+        val json = mapper.writeValueAsString(ParticipantsRoster(listOf(1L), null))
+
+        assertEquals(setOf("playerIds", "teamIds"), mapper.readTree(json).propertyNames().toSet())
+    }
+
+    @Test
+    fun `scoring rules serializes only its declared properties`() {
+        val json = mapper.writeValueAsString(ScoringRules.twoByTwentyOne())
+
+        assertEquals(
+            setOf("type", "pointsPerGame", "gamesPerMatch", "winByTwo", "capPoints"),
+            mapper.readTree(json).propertyNames().toSet()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a JSON backward-compatibility regression from #135/#131: dropping `@JvmRecord` switched Jackson to JavaBean introspection, which started serializing `isXxx()` validation helper methods on `Capacity`, `Venue`, `ParticipantsRoster`, and `ScoringRules` as extra response fields. `@JsonIgnore` keeps them out of serialization while Jakarta Validation still picks them up via reflection.
- Corrects a stale comment on `DisciplineConfig`'s factory that framed the defensive copy as a style choice rather than the only place it can happen, given `brackets` is a constructor `val`.
- Documents why the `-java-parameters` Kotlin compiler flag is load-bearing for MapStruct's constructor-parameter resolution now that `@JvmRecord` metadata is gone, so it isn't accidentally removed later.

Relates to #134 — that issue's open question (whether `ConfigurationControllerSecurityTest`'s Jackson 2 rationale still holds) is unaffected by these fixes; this PR doesn't resolve it.

## Testing
- Added `ApiJsonSerializationTest` to lock in response shape; verified it fails without the `@JsonIgnore` fix and passes with it.
- `./service/tournamentmgmt/mvnw -B -f service/tournamentmgmt/pom.xml clean verify`

## Test plan
- [x] `clean verify` passes
- [x] New `ApiJsonSerializationTest` covers the regression